### PR TITLE
[Feature] Enable openapi v3.1

### DIFF
--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -46,8 +46,8 @@ export interface ParsedRoute {
 export default async function parse(specOrPath: string | OpenAPIObject): Promise<ParsedConfig> {
     const spec = await bundleSpecification(specOrPath); //await dereference(specOrPath);
 
-    if (!spec?.openapi?.startsWith("3.0")) {
-        throw new Error("The 'specification' parameter must contain a valid version 3.0.x specification");
+    if (!spec?.openapi?.startsWith("3.")) {
+        throw new Error("The 'specification' parameter must contain a valid version 3.x specification");
     }
 
     const $refs = await $RefParser.resolve(spec);

--- a/tests/plugin-config.spec.ts
+++ b/tests/plugin-config.spec.ts
@@ -40,7 +40,7 @@ describe("Config", () => {
         await expect(fastify.ready())
             .rejects.toHaveProperty(
                 "message",
-                "The 'specification' parameter must contain a valid version 3.0.x specification"
+                "The 'specification' parameter must contain a valid version 3.x specification"
             );
     });
 
@@ -72,6 +72,19 @@ describe("Config", () => {
 
         const fastify = createFastify({
             specification: spec301,
+            controller: CONTROLLER_FILE
+        });
+
+        await expect(fastify.ready())
+            .resolves.toBe(fastify);
+    });
+
+    test("should load V3.1.0 definition with no error", async () => {
+        const spec310 = JSON.parse(JSON.stringify(PETSTORE_SPEC));
+        spec310["openapi"] = "3.1.0";
+
+        const fastify = createFastify({
+            specification: spec310,
             controller: CONTROLLER_FILE
         });
 


### PR DESCRIPTION
Upgrade dependencies (fastify, typescript, ..) and allow for schema using openapi v3.1 to be parsed